### PR TITLE
Remove unused variable definitions to improve readability

### DIFF
--- a/src/cov.jl
+++ b/src/cov.jl
@@ -48,8 +48,7 @@ Boxcar smooths an input image (or paddedview) `arr` with window size `widx` by
 """
 function boxsmooth!(out::AbstractArray, arr::AbstractArray, tot::Array{T,1}, widx::Int, widy::Int) where T
     (sx, sy) = size(arr)
-    Δx = (widx-1)÷2
-    Δy = (widy-1)÷2
+
     for j=1:(sy-widy+1)
         if (j==1)
             for n = 1:widy
@@ -101,10 +100,6 @@ function cov_avg!(bimage, ism, bism, in_image; Np::Int=33, widx::Int=129, widy::
     else
         T = Float64
     end
-
-    Δx = (widx-1)÷2
-    Δy = (widy-1)÷2
-    halfNp = (Np-1) ÷ 2
 
     (sx1, sy1) = size(in_image)
     tot = zeros(T,sx1);

--- a/src/perstar.jl
+++ b/src/perstar.jl
@@ -240,8 +240,7 @@ every detection. Math may either be performed `Float32` or `Float64`.
 - `widy::Int`: width of boxcar window in y which determines size of region used for samples for the local covariance estimate
 """
 function build_cov!(cov::Array{T,2},μ::Array{T,1},cx::Int,cy::Int,bimage::Array{T,2},bism::Array{T,4},Np::Int,widx::Int,widy::Int) where T <:Union{Float32,Float64}
-    Δx = (widx-1)÷2
-    Δy = (widy-1)÷2
+    
     halfNp = (Np-1) ÷ 2
     Δr, Δc = cx-(halfNp+1), cy-(halfNp+1)
     # Δr, Δc = cx-(halfNp-1), cy-(halfNp-1)


### PR DESCRIPTION
Hi Andrew,

Been reading your code these past few days, and on an initial pass these unused variables were sort of disorienting. I believe removing them will improve readability in the future.

Best,
Gabriel